### PR TITLE
:bug: add .dict() to post request in get_new_token

### DIFF
--- a/src/pyclarify/oauth2.py
+++ b/src/pyclarify/oauth2.py
@@ -49,9 +49,9 @@ class GetToken:
             User token.
         """
         response = requests.post(
-            url=self.auth_endpoint, headers=self.headers, data=self.credentials,
+            url=self.auth_endpoint, headers=self.headers, data=self.credentials.dict(),
         )
-
+        
         token_obj = OAuthResponse(**response.json())
         self._expire_token = datetime.datetime.now() + token_obj.expires_in
         self.access_token = token_obj.access_token


### PR DESCRIPTION
Fixes bug where `OAuthRequestBody` is not valid type in post requests.