### PR TITLE
Publish signal

### DIFF
--- a/src/pyclarify/models/requests.py
+++ b/src/pyclarify/models/requests.py
@@ -17,6 +17,7 @@ class ApiMethod(str, Enum):
     save_signals = "integration.SaveSignals"
     select_items = "clarify.SelectItems"
     select_signal = "admin.SelectSignals"
+    publish_signals = "admin.PublishSignals"
 
 
 class JSONRPCRequest(BaseModel):
@@ -45,9 +46,19 @@ class SaveParams(BaseModel):
     createdOnly: Optional[bool] = False
 
 
+class PublishParams(BaseModel):
+    integration: IntegrationID
+    itemsBySignal: Dict[InputID, SignalInfo]
+    createOnly: Optional[bool] = False
+
+
 class SaveRequest(JSONRPCRequest):
     method: ApiMethod = ApiMethod.save_signals
     params: SaveParams
+
+class PublishRequest(JSONRPCRequest):
+    method: ApiMethod = ApiMethod.publish_signals
+    params: PublishParams
 
 
 class ErrorData(BaseModel):
@@ -83,8 +94,12 @@ class SignalSaveMap(BaseModel):
     signalsByInput: Dict[InputID, Union[SaveSummary, InsertSummary]]
 
 
+class SignalPublishMap(BaseModel):
+    itemsBySignal: Dict[InputID, Union[SaveSummary, InsertSummary]]
+
+
 class SaveResponse(GenericResponse):
-    result: Optional[SignalSaveMap]
+    result: Optional[Union[SignalSaveMap, SignalPublishMap]]
 
 
 class SelectItemsParams(BaseModel):

--- a/tests/data/mock-publish-signals.json
+++ b/tests/data/mock-publish-signals.json
@@ -1,0 +1,62 @@
+{
+  "request": {
+    "name": "This is my new item",
+    "description": "I published this item through the PyClarify SDK!",
+    "labels": {
+      "Published_automatically": ["true"],
+      "SDK_version": ["0.2.0"]
+    },
+    "gapDetection": "PT5M"
+  },
+  "empty_response": {
+    "jsonrpc": "2.0",
+    "id": "1",
+    "result": {
+      "itemsBySignal": {}
+    }
+  },
+  "publish_one_response": {
+    "jsonrpc": "2.0",
+    "id": "1",
+    "result": {
+      "itemsBySignal": {
+        "some_valid_id": {
+          "id": "some_valid_id",
+          "created": true,
+          "updated": false
+        }
+      }
+    }
+  },
+  "update_one_response": {
+    "jsonrpc": "2.0",
+    "id": "1",
+    "result": {
+      "itemsBySignal": {
+        "some_valid_id": {
+          "id": "some_valid_id",
+          "created": false,
+          "updated": true
+        }
+      }
+    }
+  },
+  "publish_two_response": {
+    "jsonrpc": "2.0",
+    "id": "1",
+    "result": {
+      "itemsBySignal": {
+        "some_valid_id_1": {
+          "id": "some_valid_id_1",
+          "created": true,
+          "updated": false
+        },
+        "some_valid_id_2": {
+          "id": "some_valid_id_2",
+          "created": true,
+          "updated": false
+        }
+      }
+    }
+  }
+}

--- a/tests/test_client_publish_signals.py
+++ b/tests/test_client_publish_signals.py
@@ -1,0 +1,143 @@
+import sys
+import unittest
+import json
+from datetime import datetime, timedelta
+from unittest.mock import patch
+import requests
+from http import HTTPStatus
+
+# Standard library imports...
+
+
+sys.path.insert(1, "src/")
+from pyclarify import APIClient, SignalInfo, DataFrame
+from pyclarify.models.auth import ClarifyCredential, OAuthRequestBody, OAuthResponse
+import pyclarify
+
+signal_id = "test_publish_signal"
+client = APIClient("./tests/clarify-credentials-8.json")
+
+
+# item_meta_data = SignalInfo(
+#     name="This is my new signal",
+#     description="I created this signal through the PyClarify SDK!",
+#     labels={
+#         "Test_signal_version": ["3"],
+#         "SDK_version": ["0.2.0"]
+#     },
+#     gapDetection="PT5M",
+# )
+
+# response = client.save_signals(
+#     inputs={"test_signal_3" : item_meta_data},
+#     created_only=False #False = create new signal, True = update existing signal
+# )
+# print(response)
+# test_signal_id_1 = "c64j2vfqfsj0hurrtjdg"
+# test_signal_id_2 = "c64j35nqfsj0hurrtje0"
+# test_signal_id_3 = "c64j7pnqfsj0hurrtjfg"
+
+# item_meta_data_1 = SignalInfo(
+#     name="Item numero tres",
+#     description="I published this item through the PyClarify SDK!",
+#     labels={
+#         "Published_automatically": ["True"],
+#         "SDK_version": ["0.2.0"]
+#     },
+#     gapDetection="PT5M",
+# )
+
+# item_meta_data_2 = SignalInfo(
+#     name="Item numero quatro",
+#     description="I published this item through the PyClarify SDK!",
+#     labels={
+#         "Published_automatically": ["True"],
+#         "SDK_version": ["0.2.0"]
+#     },
+#     gapDetection="PT5M",
+# )
+
+
+# response = client.publish_signals(signals={test_signal_id_3: item_meta_data_1, test_signal_id_2: item_meta_data_2}, created_only=False)
+# print(response)
+
+
+class TestClarifySaveClient(unittest.TestCase):
+    def setUp(self):
+        self.client = APIClient("./tests/data/mock-clarify-credentials.json")
+        
+        with open("./tests/data/mock-client-common.json") as f:
+            self.mock_data = json.load(f)
+        self.mock_access_token = self.mock_data["mock_access_token"]
+
+        with open("./tests/data/mock-publish-signals.json") as f:
+            self.mock_data = json.load(f)
+
+    @patch("pyclarify.client.RawClient.get_token")
+    @patch("pyclarify.client.requests.post")
+    def test_send_nonexisting_signal_request(self, client_req_mock, get_token_mock):
+        get_token_mock.return_value = self.mock_access_token
+        client_req_mock.return_value.ok = True
+        client_req_mock.return_value.json = lambda: self.mock_data["empty_response"]
+
+        item_meta_data = SignalInfo(
+            **self.mock_data["request"]
+        )
+        result = self.client.publish_signals(
+            signals={"id_does_not_exist": item_meta_data}, created_only=True
+        )
+
+        self.assertEqual(result.result.itemsBySignal, {})
+    
+    @patch("pyclarify.client.RawClient.get_token")
+    @patch("pyclarify.client.requests.post")
+    def test_send_publish_one_signal(self, client_req_mock, get_token_mock):
+        get_token_mock.return_value = self.mock_access_token
+        client_req_mock.return_value.ok = True
+        client_req_mock.return_value.json = lambda: self.mock_data["publish_one_response"]
+
+        item_meta_data = SignalInfo(
+            **self.mock_data["request"]
+        )
+        result = self.client.publish_signals(
+            signals={"some_valid_id": item_meta_data}, created_only=True
+        )
+        self.assertTrue(result.result.itemsBySignal["some_valid_id"].created)
+        self.assertFalse(result.result.itemsBySignal["some_valid_id"].updated)
+
+    
+    @patch("pyclarify.client.RawClient.get_token")
+    @patch("pyclarify.client.requests.post")
+    def test_send_publish_two_signals(self, client_req_mock, get_token_mock):
+        get_token_mock.return_value = self.mock_access_token
+        client_req_mock.return_value.ok = True
+        client_req_mock.return_value.json = lambda: self.mock_data["publish_two_response"]
+
+        item_meta_data = SignalInfo(
+            **self.mock_data["request"]
+        )
+        result = self.client.publish_signals(
+            signals={"some_valid_id_1": item_meta_data, "some_valid_id_2": item_meta_data}, created_only=True
+        )
+        self.assertTrue(result.result.itemsBySignal["some_valid_id_1"].created)
+        self.assertTrue(result.result.itemsBySignal["some_valid_id_2"].created)
+
+    @patch("pyclarify.client.RawClient.get_token")
+    @patch("pyclarify.client.requests.post")
+    def test_send_update_one_signal(self, client_req_mock, get_token_mock):
+        get_token_mock.return_value = self.mock_access_token
+        client_req_mock.return_value.ok = True
+        client_req_mock.return_value.json = lambda: self.mock_data["update_one_response"]
+
+        item_meta_data = SignalInfo(
+            **self.mock_data["request"]
+        )
+        result = self.client.publish_signals(
+            signals={"some_valid_id": item_meta_data}, created_only=True
+        )
+
+        self.assertFalse(result.result.itemsBySignal["some_valid_id"].created)
+        self.assertTrue(result.result.itemsBySignal["some_valid_id"].updated)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add publish signal method for creating items based on a `SignalInfo` model and a `Signal_ID` as key.