### PR TITLE
include typing_extensions in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ python_requires = >=3.7
 install_requires = 
     requests
     pydantic ==1.8.2
+    typing_extensions ==3.10.0.2
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
include typing_extensions in setup.cfg to cover installations with python==3.7 version.