### PR TITLE
Add reworked publish signal method

### DIFF
--- a/tests/data/mock-clarify-client-publish-signals.json
+++ b/tests/data/mock-clarify-client-publish-signals.json
@@ -1,0 +1,81 @@
+{
+  "test_cases": [
+    {
+      "comments": "No input",
+      "response": {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "result": {
+          "itemsBySignal": {}
+        },
+        "error": null
+      }
+    },
+    {
+      "comments": "get all signals with items",
+      "dummy-items": {
+        "c7kmudvqfsjfb27kpr30": {
+          "name": "my test signal",
+          "type": "numeric",
+          "description": "A test Item for debugging.",
+          "labels": {},
+          "annotations": {},
+          "engUnit": "",
+          "sourceType": "measurement",
+          "sampleInterval": null,
+          "gapDetection": null,
+          "enumValues": {},
+          "visible": true
+        },
+        "c7kmudvqfsjfb27kpr3g": {
+          "name": "my test signal 2",
+          "type": "numeric",
+          "description": "A test Item for debugging.",
+          "labels": {},
+          "annotations": {},
+          "engUnit": "",
+          "sourceType": "measurement",
+          "sampleInterval": null,
+          "gapDetection": null,
+          "enumValues": {},
+          "visible": false
+        }
+      },
+      "response": {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "result": {
+          "itemsBySignal": {
+            "c7kmudvqfsjfb27kpr30": {
+              "id": "c7o06mvqfsjalqv80iqg",
+              "created": true,
+              "updated": false
+            },
+            "c7kmudvqfsjfb27kpr3g": {
+              "id": "c7o07lvqfsjalqv80ir0",
+              "created": true,
+              "updated": false
+            }
+          }
+        },
+        "error": null
+      }
+    },
+    {
+      "response": {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "result": {
+          "itemsBySignal": {
+            "c7kmudvqfsjfb27kpr30": {
+              "id": "c7o06mvqfsjalqv80iqg",
+              "created": false,
+              "updated": false
+            }
+          }
+        },
+        "error": null
+      }
+    }
+  ]
+}

--- a/tests/test_clarify_client_publish_signals.py
+++ b/tests/test_clarify_client_publish_signals.py
@@ -1,0 +1,132 @@
+"""
+Copyright 2021 Clarify
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+import unittest
+import json
+from unittest.mock import patch
+
+# Standard library imports...
+
+sys.path.insert(1, "src/")
+from pyclarify import ClarifyClient, SignalInfo, DataFrame
+
+
+class TestClarifyClientPublishSignals(unittest.TestCase):
+    def setUp(self):
+        self.client = ClarifyClient("./tests/data/mock-clarify-credentials.json")
+
+        with open("./tests/data/mock-clarify-client-publish-signals.json") as f:
+            self.mock_data = json.load(f)
+        self.test_cases = self.mock_data["test_cases"]
+        dummy_items = self.test_cases[1]["dummy-items"]
+        self.resource_ids = list(dummy_items.keys())
+        self.items = list(dummy_items.values())
+
+        with open("./tests/data/mock-client-common.json") as f:
+            self.mock_data = json.load(f)
+        self.mock_access_token = self.mock_data["mock_access_token"]
+
+    @patch("pyclarify.client.RawClient.get_token")
+    @patch("pyclarify.client.requests.post")
+    def test_publish_no_item(self, client_req_mock, get_token_mock):
+        get_token_mock.return_value = self.mock_access_token
+        client_req_mock.return_value.ok = True
+        client_req_mock.return_value.json = lambda: self.test_cases[0]["response"]
+
+        response_data = self.client.publish_signals(resource_ids=[], items=[])
+        for x in response_data.result.itemsBySignal:
+            self.assertEqual(x, {})
+
+    @patch("pyclarify.client.RawClient.get_token")
+    @patch("pyclarify.client.requests.post")
+    def test_publish_one_item(self, client_req_mock, get_token_mock):
+        get_token_mock.return_value = self.mock_access_token
+        client_req_mock.return_value.ok = True
+        client_req_mock.return_value.json = lambda: self.test_cases[1]["response"]
+
+        response_data = self.client.publish_signals(resource_ids=self.resource_ids[:1], items=self.items[:1])
+        for x in response_data.result.itemsBySignal:
+            self.assertEqual(x, self.resource_ids[0])
+            break
+
+    @patch("pyclarify.client.RawClient.get_token")
+    @patch("pyclarify.client.requests.post")
+    def test_publish_multiple_signals(self, client_req_mock, get_token_mock):
+        get_token_mock.return_value = self.mock_access_token
+        client_req_mock.return_value.ok = True
+        client_req_mock.return_value.json = lambda: self.test_cases[1]["response"]
+
+        response_data = self.client.publish_signals(resource_ids=self.resource_ids, items=self.items)
+        for i, x in enumerate(response_data.result.itemsBySignal):
+            self.assertEqual(x, self.resource_ids[i])
+
+
+    @patch("pyclarify.client.RawClient.get_token")
+    @patch("pyclarify.client.requests.post")
+    def test_publish_without_resource_ids(self, client_req_mock, get_token_mock):
+        get_token_mock.return_value = self.mock_access_token
+        client_req_mock.return_value.ok = True
+        client_req_mock.return_value.json = lambda: self.test_cases[0]["response"]
+
+        response_data = self.client.publish_signals(resource_ids=[], items=self.items)
+        for x in response_data.result.itemsBySignal:
+            self.assertEqual(x, {})
+    
+    
+    @patch("pyclarify.client.RawClient.get_token")
+    @patch("pyclarify.client.requests.post")
+    def test_publish_without_items(self, client_req_mock, get_token_mock):
+        get_token_mock.return_value = self.mock_access_token
+        client_req_mock.return_value.ok = True
+        client_req_mock.return_value.json = lambda: self.test_cases[0]["response"]
+
+        response_data = self.client.publish_signals(resource_ids=self.resource_ids, items=[])
+        for x in response_data.result.itemsBySignal:
+            self.assertEqual(x, {})
+    
+    
+    @patch("pyclarify.client.RawClient.get_token")
+    @patch("pyclarify.client.requests.post")
+    def test_publish_with_too_many_resource_ids(self, client_req_mock, get_token_mock):
+        get_token_mock.return_value = self.mock_access_token
+        client_req_mock.return_value.ok = True
+        client_req_mock.return_value.json = lambda: self.test_cases[1]["response"]
+        
+        response_data = self.client.publish_signals(resource_ids=self.resource_ids * 2, items=self.items)
+        for x in response_data.result.itemsBySignal:
+            self.assertEqual(x, self.resource_ids[0])
+            break
+
+
+    @patch("pyclarify.client.RawClient.get_token")
+    @patch("pyclarify.client.requests.post")
+    def test_publish_with_too_many_items(self, client_req_mock, get_token_mock):
+        get_token_mock.return_value = self.mock_access_token
+        client_req_mock.return_value.ok = True
+        client_req_mock.return_value.json = lambda: self.test_cases[2]["response"]
+
+        response_data = self.client.publish_signals(resource_ids=self.resource_ids, items=self.items * 2)
+        for x in response_data.result.itemsBySignal:
+            self.assertEqual(x, self.resource_ids[0])
+            break
+        
+        self.assertFalse(response_data.result.itemsBySignal[x].created)
+        self.assertFalse(response_data.result.itemsBySignal[x].updated)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adding a pythonic version of `publish_signals` to the Clarify Client.

```python
def publish_signals(
        self,
        resource_ids: List[ResourceID],
        items: List[Item],
        create_only: bool = False,
        integration: str = None,
    ) -> Response:
```

