### PR TITLE
Updated model, tests, client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ clarify-credentials-dev.json
 
 # test files
 test.py
+response.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,9 @@ Changes are grouped as follows
   merged = DataFrame.merge([df, new_df])
   ```
 
+## Changed
+- `pyclarify.client.ClarifyClient.select_items()` now responds with `JSON:API` format. 
+
 ## Removed
 
 - `pyclarify.client.APIClient`

--- a/src/pyclarify/fields/constraints.py
+++ b/src/pyclarify/fields/constraints.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import annotations
-from inspect import Attribute
 from pydantic import BaseModel, constr, conint
 from typing import List, Union, Dict
 from enum import Enum

--- a/src/pyclarify/fields/constraints.py
+++ b/src/pyclarify/fields/constraints.py
@@ -14,8 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from __future__ import annotations
+from inspect import Attribute
 from pydantic import BaseModel, constr, conint
-from typing import List, Union
+from typing import List, Union, Dict
 from enum import Enum
 from datetime import datetime
 
@@ -54,6 +56,14 @@ class TypeSignal(str, Enum):
 
 
 class ResourceMetadata(BaseModel):
+    annotations: Dict[AnnotationKey, str]
+    attributesHash: str
+    relationshipsHash: str
+    updatedAt: datetime
+    createdAt: datetime
+
+# TODO: Will be removed when we have a proper select method
+class SignalResourceMetadata(BaseModel):
     contentHash: str
     updatedAt: datetime
     createdAt: datetime

--- a/src/pyclarify/fields/query.py
+++ b/src/pyclarify/fields/query.py
@@ -21,8 +21,9 @@ from pydantic.fields import Optional
 from pydantic import BaseModel, Extra
 from enum import Enum
 from typing import Union, List, Dict
-from datetime import datetime
 from pydantic.class_validators import root_validator
+from typing_extensions import Literal
+from datetime import datetime, timedelta
 
 
 class QueryParams(BaseModel):
@@ -126,3 +127,9 @@ class DateField(BaseModel):
 
     class Config:
         extra = Extra.forbid
+class ResourceQuery(BaseModel, extra=Extra.forbid):
+    sort: List[str] = []
+    filter: dict  # TODO: ResourceFilter (https://docs.clarify.io/v1.1/reference/filtering)
+    limit: int = 10
+    skip: int = 0
+    total: bool = False

--- a/src/pyclarify/jsonrpc/client.py
+++ b/src/pyclarify/jsonrpc/client.py
@@ -179,11 +179,11 @@ class JSONRPCClient:
         """
         for payload in self.payload_list:
             
-            logging.debug(f"--> {self.base_url}, req: {payload}")
+            print(f"--> {self.base_url}, req: {payload}")
             res = requests.post(
                 self.base_url, data=json.dumps(payload), headers=self.headers
             )
-            logging.debug(f"<-- {self.base_url} ({res.status_code})")
+            print(f"<-- {self.base_url} ({res.status_code})")
             if not res.ok:
                 err = {
                     "code": res.status_code,

--- a/src/pyclarify/jsonrpc/client.py
+++ b/src/pyclarify/jsonrpc/client.py
@@ -179,11 +179,11 @@ class JSONRPCClient:
         """
         for payload in self.payload_list:
             
-            print(f"--> {self.base_url}, req: {payload}")
+            logging.debug(f"--> {self.base_url}, req: {payload}")
             res = requests.post(
                 self.base_url, data=json.dumps(payload), headers=self.headers
             )
-            print(f"<-- {self.base_url} ({res.status_code})")
+            logging.debug(f"<-- {self.base_url} ({res.status_code})")
             if not res.ok:
                 err = {
                     "code": res.status_code,

--- a/src/pyclarify/jsonrpc/client.py
+++ b/src/pyclarify/jsonrpc/client.py
@@ -67,7 +67,7 @@ def increment_id(func):
 def iterator(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        LEGAL_ITERATOR_TYPES = [ApiMethod.select_items]
+        LEGAL_ITERATOR_TYPES = [] # No methods use iterator as of now.
         payload_list = []
         payload = json.loads(args[1])
 
@@ -178,6 +178,7 @@ class JSONRPCClient:
 
         """
         for payload in self.payload_list:
+            
             logging.debug(f"--> {self.base_url}, req: {payload}")
             res = requests.post(
                 self.base_url, data=json.dumps(payload), headers=self.headers

--- a/src/pyclarify/views/generics.py
+++ b/src/pyclarify/views/generics.py
@@ -45,7 +45,10 @@ class JSONRPCRequest(BaseModel):
     params: Dict = {}
 
     class Config:
-        json_encoders = {timedelta: timedelta_isoformat, datetime: time_to_string}
+        json_encoders = {
+            timedelta: timedelta_isoformat,
+            datetime: time_to_string
+        }
 
 
 @validate_arguments

--- a/src/pyclarify/views/signals.py
+++ b/src/pyclarify/views/signals.py
@@ -20,7 +20,7 @@ from pydantic.fields import Optional
 from pydantic.json import timedelta_isoformat
 from typing import List, Dict, Union
 from pyclarify.fields.constraints import (
-    ResourceMetadata,
+    SignalResourceMetadata,
     TypeSignal,
     SourceTypeSignal,
     LabelsKey,
@@ -52,7 +52,7 @@ class SignalInfo(BaseModel):
 class Signal(SignalInfo):
     item: Union[ResourceID, None]
     inputId: InputID
-    meta: ResourceMetadata
+    meta: SignalResourceMetadata
 
 
 class SelectSignalsItemsParams(BaseModel, extra=Extra.forbid):

--- a/tests/data/mock-clarify-client-select-items.json
+++ b/tests/data/mock-clarify-client-select-items.json
@@ -12,51 +12,42 @@
         "jsonrpc": "2.0",
         "id": "1",
         "result": {
-          "items": {
-            "c5vv12btaf7d0qbk0l0g": {
-              "name": "c5vv12btaf7d0qbk0l0g",
-              "valueType": "numeric",
-              "description": "Test description",
-              "labels": { "data-source": [], "location": [] },
-              "annotations": {},
-              "engUnit": "",
-              "enumValues": {},
-              "sourceType": "measurement",
-              "sampleInterval": null,
-              "gapDetection": "3600.0"
+          "meta": { "total": -1, "groupIncludedByType": false },
+          "data": [
+            {
+              "type": "items",
+              "id": "c5ep6ojsbu8cohpih9bg",
+              "meta": {
+                "attributesHash": "df105ac1e2dde32794909e3be8c6e435ab1c12f3",
+                "relationshipsHash": "5f36b2ea290645ee34d943220a14b54ee5ea5be5",
+                "annotations": { "clarify/industry-type": "mysterybox" },
+                "createdAt": "2021-10-06T12:15:30.344Z",
+                "updatedAt": "2022-03-25T09:58:19.598Z"
+              },
+              "attributes": {
+                "name": "Electricity price",
+                "description": "Used by Demo data timeline: Mystery box.",
+                "valueType": "numeric",
+                "sourceType": "prediction",
+                "engUnit": "EUR/kWh",
+                "sampleInterval": null,
+                "gapDetection": "PT2H",
+                "labels": {
+                  "city": ["Oslo"],
+                  "country": ["Norway"],
+                  "data-source": ["Nordpool"],
+                  "location": ["Oslo"]
+                },
+                "enumValues": {},
+                "visible": true
+              },
+              "relationships": {}
             }
-          }
+          ]
         }
       }
     },
-    {
-      "comments": "get items matching criteria, return only data",
-      "args": {
-        "filter": {
-          "fields": { "name": { "value": ["Electricity"], "operator": "$in" } }
-        },
-        "skip": 0,
-        "not_before": "2021-10-10T21:50:06Z",
-        "before": "2021-10-11T22:50:06Z",
-        "rollup": "PT1H"
-      },
-      "response": {
-        "jsonrpc": "2.0",
-        "id": "1",
-        "result": {
-          "data": {
-            "times": ["2021-10-10T21:00:00+00:00", "2021-10-10T22:00:00+00:00"],
-            "series": {
-              "item_id_avg": [0.0, 0.0],
-              "item_id_count": [20.0, 20.0],
-              "item_id_max": [0.0, 0.0],
-              "item_id_min": [0.0, 0.0],
-              "item_id_sum": [0.0, 0.0]
-            }
-          }
-        }
-      }
-    },
+    
     {
       "comments": "get 1100 items, return metadata and no data",
       "args": {
@@ -68,20 +59,38 @@
         "jsonrpc": "2.0",
         "id": "1",
         "result": {
-          "items": {
-            "c5vv12btaf7d0qbk0l0g": {
-              "name": "c5vv12btaf7d0qbk0l0g",
-              "valueType": "numeric",
-              "description": "Test description",
-              "labels": { "data-source": [], "location": [] },
-              "annotations": {},
-              "engUnit": "",
-              "enumValues": {},
-              "sourceType": "measurement",
-              "sampleInterval": null,
-              "gapDetection": "3600.0"
+          "meta": { "total": -1, "groupIncludedByType": false },
+          "data": [
+            {
+              "type": "items",
+              "id": "c5ep6ojsbu8cohpih9bg",
+              "meta": {
+                "attributesHash": "df105ac1e2dde32794909e3be8c6e435ab1c12f3",
+                "relationshipsHash": "5f36b2ea290645ee34d943220a14b54ee5ea5be5",
+                "annotations": { "clarify/industry-type": "mysterybox" },
+                "createdAt": "2021-10-06T12:15:30.344Z",
+                "updatedAt": "2022-03-25T09:58:19.598Z"
+              },
+              "attributes": {
+                "name": "Electricity price",
+                "description": "Used by Demo data timeline: Mystery box.",
+                "valueType": "numeric",
+                "sourceType": "prediction",
+                "engUnit": "EUR/kWh",
+                "sampleInterval": null,
+                "gapDetection": "PT2H",
+                "labels": {
+                  "city": ["Oslo"],
+                  "country": ["Norway"],
+                  "data-source": ["Nordpool"],
+                  "location": ["Oslo"]
+                },
+                "enumValues": {},
+                "visible": true
+              },
+              "relationships": {}
             }
-          }
+          ]
         }
       }
     },
@@ -92,25 +101,44 @@
           "fields": { "name": { "value": ["Electricity"], "operator": "$in" } }
         },
         "skip": 0,
-        "limit": 100,
-        "not_before": "2021-10-10T21:50:06Z",
-        "before": "2021-10-11T22:50:06Z",
-        "rollup": "PT1H"
+        "limit": 100
       },
       "response": {
         "jsonrpc": "2.0",
         "id": "1",
         "result": {
-          "data": {
-            "times": ["2021-10-10T21:00:00+00:00", "2021-10-10T22:00:00+00:00"],
-            "series": {
-              "item_id_avg": [0.0, 0.0],
-              "item_id_count": [20.0, 20.0],
-              "item_id_max": [0.0, 0.0],
-              "item_id_min": [0.0, 0.0],
-              "item_id_sum": [0.0, 0.0]
+          "meta": { "total": -1, "groupIncludedByType": false },
+          "data": [
+            {
+              "type": "items",
+              "id": "c5ep6ojsbu8cohpih9bg",
+              "meta": {
+                "attributesHash": "df105ac1e2dde32794909e3be8c6e435ab1c12f3",
+                "relationshipsHash": "5f36b2ea290645ee34d943220a14b54ee5ea5be5",
+                "annotations": { "clarify/industry-type": "mysterybox" },
+                "createdAt": "2021-10-06T12:15:30.344Z",
+                "updatedAt": "2022-03-25T09:58:19.598Z"
+              },
+              "attributes": {
+                "name": "Electricity price",
+                "description": "Used by Demo data timeline: Mystery box.",
+                "valueType": "numeric",
+                "sourceType": "prediction",
+                "engUnit": "EUR/kWh",
+                "sampleInterval": null,
+                "gapDetection": "PT2H",
+                "labels": {
+                  "city": ["Oslo"],
+                  "country": ["Norway"],
+                  "data-source": ["Nordpool"],
+                  "location": ["Oslo"]
+                },
+                "enumValues": {},
+                "visible": true
+              },
+              "relationships": {}
             }
-          }
+          ]
         }
       }
     }

--- a/tests/data/mock-models-request.json
+++ b/tests/data/mock-models-request.json
@@ -8,8 +8,11 @@
     "include": false
   },
   "select_items_params": {
-    "items": {},
-    "data": {}
+    "query": {
+      "filter": {}
+    },
+    "include": [],
+    "groupIncludedByType": false
   },
   "insert_params": {
     "integration": "c618rbfqfsj7mjkj0ss1",

--- a/tests/data/mock-models-response.json
+++ b/tests/data/mock-models-response.json
@@ -36,31 +36,94 @@
     }
   },
   "select_items_response": {
-    "items": {
-      "c5vv12btaf7d0qbk0l0g": {
-        "name": "c5vv12btaf7d0qbk0l0g",
-        "valueType": "numeric",
-        "description": "Test description",
-        "labels": { "data-source": [], "location": [] },
-        "annotations": {},
-        "engUnit": "",
-        "enumValues": {},
-        "sourceType": "measurement",
-        "sampleInterval": null,
-        "gapDetection": "3600.0"
-      }
-    },
-
-    "data": {
-      "times": ["2021-10-10T21:00:00+00:00", "2021-10-10T22:00:00+00:00"],
-      "series": {
-        "item_id_avg": [0.0, 0.0],
-        "item_id_count": [20.0, 20.0],
-        "item_id_max": [0.0, 0.0],
-        "item_id_min": [0.0, 0.0],
-        "item_id_sum": [0.0, 0.0]
-      }
-    }
+      "meta": { "total": -1, "groupIncludedByType": false },
+      "data": [
+        {
+          "type": "items",
+          "id": "c5ep6ojsbu8cohpih9dg",
+          "meta": {
+            "attributesHash": "2a72c40f64110ecb61f3c6dfea1356d8e3ac009b",
+            "relationshipsHash": "5f36b2ea290645ee34d943220a14b54ee5ea5be5",
+            "annotations": { "clarify/industry-type": "mysterybox" },
+            "createdAt": "2021-10-06T12:15:30.349Z",
+            "updatedAt": "2022-03-25T09:58:19.603Z"
+          },
+          "attributes": {
+            "name": "Airborne particulate matter (PM10)",
+            "description": "Used by Demo data timeline: Mystery box.",
+            "valueType": "numeric",
+            "sourceType": "measurement",
+            "engUnit": "µg/m³",
+            "sampleInterval": null,
+            "gapDetection": "PT6H",
+            "labels": {
+              "city": ["Trondheim"],
+              "country": ["NO"],
+              "data-source": ["Open AQ"],
+              "location": ["Trondheim"]
+            },
+            "enumValues": {},
+            "visible": true
+          },
+          "relationships": {}
+        },
+        {
+          "type": "items",
+          "id": "c5ep6ojsbu8cohpih9f0",
+          "meta": {
+            "attributesHash": "136ea320a5bfa8d7928a19562449d88fd1cbaf39",
+            "relationshipsHash": "5f36b2ea290645ee34d943220a14b54ee5ea5be5",
+            "annotations": { "clarify/industry-type": "mysterybox" },
+            "createdAt": "2021-10-06T12:15:30.351Z",
+            "updatedAt": "2022-03-25T09:58:19.607Z"
+          },
+          "attributes": {
+            "name": "Passing cars",
+            "description": "Used by Demo data timeline: Mystery box.",
+            "valueType": "numeric",
+            "sourceType": "measurement",
+            "engUnit": "nbr/h",
+            "sampleInterval": null,
+            "gapDetection": "PT2H",
+            "labels": {
+              "city": ["Trondheim"],
+              "country": ["Norway"],
+              "data-source": ["Traffic data"],
+              "location": ["Væretunnelen"]
+            },
+            "enumValues": {},
+            "visible": true
+          },
+          "relationships": {}
+        },
+        {
+          "type": "items",
+          "id": "c5ep6ojsbu8cohpih9g0",
+          "meta": {
+            "attributesHash": "e7949437562e4319d79c9878890ea34bf0829eec",
+            "relationshipsHash": "5f36b2ea290645ee34d943220a14b54ee5ea5be5",
+            "annotations": { "clarify/industry-type": "mysterybox" },
+            "createdAt": "2021-10-06T12:15:30.353Z",
+            "updatedAt": "2022-03-25T09:58:19.61Z"
+          },
+          "attributes": {
+            "name": "Average Wind Speed",
+            "description": "Used by Demo data timeline: Maritime & Mystery box.",
+            "valueType": "numeric",
+            "sourceType": "measurement",
+            "engUnit": "m/s",
+            "sampleInterval": null,
+            "gapDetection": "PT2H",
+            "labels": {
+              "data-source": ["Live Port Weather data provider"],
+              "location": ["Port B"]
+            },
+            "enumValues": {},
+            "visible": true
+          },
+          "relationships": {}
+        }
+      ]
   },
   "select_signals_response": {
     "signals": {

--- a/tests/test_clarify_client_publish_signals.py
+++ b/tests/test_clarify_client_publish_signals.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 # Standard library imports...
 
 sys.path.insert(1, "src/")
-from pyclarify import ClarifyClient, SignalInfo, DataFrame
+from pyclarify import ClarifyClient, DataFrame
 
 
 class TestClarifyClientPublishSignals(unittest.TestCase):

--- a/tests/test_clarify_client_select_items.py
+++ b/tests/test_clarify_client_select_items.py
@@ -22,7 +22,8 @@ from unittest.mock import patch
 # Standard library imports...
 
 sys.path.insert(1, "src/")
-from pyclarify import ClarifyClient, ItemInfo, DataFrame
+from pyclarify import ClarifyClient, DataFrame
+from pyclarify.views.items import ItemSelectView
 from pyclarify.views.generics import Response, SelectItemsResponse
 from pyclarify.query import Filter
 
@@ -49,8 +50,8 @@ class TestClarifyClientSelectItems(unittest.TestCase):
 
         response_data = self.client.select_items()
 
-        for x in response_data.result.items:
-            self.assertIsInstance(response_data.result.items[x], ItemInfo)
+        for x in response_data.result.data:
+            self.assertIsInstance(x, ItemSelectView)
 
     @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
     @patch("pyclarify.client.requests.post")
@@ -64,8 +65,8 @@ class TestClarifyClientSelectItems(unittest.TestCase):
             filter=Filter(**test_case["args"]["filter"])
         )
 
-        for x in response_data.result.items:
-            self.assertIsInstance(response_data.result.items[x], ItemInfo)
+        for x in response_data.result.data:
+            self.assertIsInstance(x, ItemSelectView)
 
     @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
     @patch("pyclarify.client.requests.post")
@@ -77,101 +78,100 @@ class TestClarifyClientSelectItems(unittest.TestCase):
 
         response_data = self.client.select_items(**test_case["args"])
 
-        for x in response_data.result.items:
-            self.assertIsInstance(response_data.result.items[x], ItemInfo)
+        for x in response_data.result.data:
+            self.assertIsInstance(x, ItemSelectView)
 
-    @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
-    @patch("pyclarify.client.requests.post")
-    def test_get_items_data_with_none(self, client_req_mock, get_token_mock):
-        test_case = self.test_cases[1]
-        get_token_mock.return_value = self.mock_access_token
-        client_req_mock.return_value.ok = True
-        client_req_mock.return_value.json = lambda: test_case["response"]
+    # @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
+    # @patch("pyclarify.client.requests.post")
+    # def test_get_items_data_with_none(self, client_req_mock, get_token_mock):
+    #     test_case = self.test_cases[1]
+    #     get_token_mock.return_value = self.mock_access_token
+    #     client_req_mock.return_value.ok = True
+    #     client_req_mock.return_value.json = lambda: test_case["response"]
 
-        response_data = self.client.select_items(include_metadata=False)
+    #     response_data = self.client.select_items()
+    #     self.assertIsNone(response_data.result.data)
+    #     self.assertIsInstance(response_data.result.data, DataFrame)
 
-        self.assertIsNone(response_data.result.items)
-        self.assertIsInstance(response_data.result.data, DataFrame)
+    # @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
+    # @patch("pyclarify.client.requests.post")
+    # def test_get_items_data_with_ids(self, client_req_mock, get_token_mock):
+    #     test_case = self.test_cases[1]
+    #     get_token_mock.return_value = self.mock_access_token
+    #     client_req_mock.return_value.ok = True
+    #     client_req_mock.return_value.json = lambda: test_case["response"]
 
-    @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
-    @patch("pyclarify.client.requests.post")
-    def test_get_items_data_with_ids(self, client_req_mock, get_token_mock):
-        test_case = self.test_cases[1]
-        get_token_mock.return_value = self.mock_access_token
-        client_req_mock.return_value.ok = True
-        client_req_mock.return_value.json = lambda: test_case["response"]
+    #     response_data = self.client.select_items(
+    #         filter=Filter(**test_case["args"]["filter"])
+    #     )
 
-        response_data = self.client.select_items(
-            include_metadata=False, filter=Filter(**test_case["args"]["filter"])
-        )
+    #     self.assertIsNone(response_data.result.data)
+    #     self.assertIsInstance(response_data.result.data, DataFrame)
 
-        self.assertIsNone(response_data.result.items)
-        self.assertIsInstance(response_data.result.data, DataFrame)
+    # @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
+    # @patch("pyclarify.client.requests.post")
+    # def test_get_items_data_with_not_before(self, client_req_mock, get_token_mock):
+    #     test_case = self.test_cases[1]
+    #     get_token_mock.return_value = self.mock_access_token
+    #     client_req_mock.return_value.ok = True
+    #     client_req_mock.return_value.json = lambda: test_case["response"]
 
-    @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
-    @patch("pyclarify.client.requests.post")
-    def test_get_items_data_with_not_before(self, client_req_mock, get_token_mock):
-        test_case = self.test_cases[1]
-        get_token_mock.return_value = self.mock_access_token
-        client_req_mock.return_value.ok = True
-        client_req_mock.return_value.json = lambda: test_case["response"]
+    #     response_data = self.client.select_items(
+    #         not_before=test_case["args"]["not_before"]
+    #     )
 
-        response_data = self.client.select_items(
-            include_metadata=False, not_before=test_case["args"]["not_before"]
-        )
+    #     self.assertIsNone(response_data.result.data)
+    #     self.assertIsInstance(response_data.result.data, DataFrame)
 
-        self.assertIsNone(response_data.result.items)
-        self.assertIsInstance(response_data.result.data, DataFrame)
+    # @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
+    # @patch("pyclarify.client.requests.post")
+    # def test_get_items_data_with_before(self, client_req_mock, get_token_mock):
+    #     test_case = self.test_cases[1]
+    #     get_token_mock.return_value = self.mock_access_token
+    #     client_req_mock.return_value.ok = True
+    #     client_req_mock.return_value.json = lambda: test_case["response"]
 
-    @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
-    @patch("pyclarify.client.requests.post")
-    def test_get_items_data_with_before(self, client_req_mock, get_token_mock):
-        test_case = self.test_cases[1]
-        get_token_mock.return_value = self.mock_access_token
-        client_req_mock.return_value.ok = True
-        client_req_mock.return_value.json = lambda: test_case["response"]
+    #     response_data = self.client.select_items(
+    #         before=test_case["args"]["before"]
+    #     )
 
-        response_data = self.client.select_items(
-            include_metadata=False, before=test_case["args"]["before"]
-        )
+    #     self.assertIsNone(response_data.result.data)
+    #     self.assertIsInstance(response_data.result.data, DataFrame)
 
-        self.assertIsNone(response_data.result.items)
-        self.assertIsInstance(response_data.result.data, DataFrame)
+    # @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
+    # @patch("pyclarify.client.requests.post")
+    # def test_get_items_data_with_rollup(self, client_req_mock, get_token_mock):
+    #     test_case = self.test_cases[1]
+    #     get_token_mock.return_value = self.mock_access_token
+    #     client_req_mock.return_value.ok = True
+    #     client_req_mock.return_value.json = lambda: test_case["response"]
 
-    @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
-    @patch("pyclarify.client.requests.post")
-    def test_get_items_data_with_rollup(self, client_req_mock, get_token_mock):
-        test_case = self.test_cases[1]
-        get_token_mock.return_value = self.mock_access_token
-        client_req_mock.return_value.ok = True
-        client_req_mock.return_value.json = lambda: test_case["response"]
+    #     response_data = self.client.select_items(
+    #         rollup=test_case["args"]["rollup"]
+    #     )
 
-        response_data = self.client.select_items(
-            include_metadata=False, rollup=test_case["args"]["rollup"]
-        )
+    #     self.assertIsNone(response_data.result.data)
+    #     self.assertIsInstance(response_data.result.data, DataFrame)
 
-        self.assertIsNone(response_data.result.items)
-        self.assertIsInstance(response_data.result.data, DataFrame)
+    # @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
+    # @patch("pyclarify.client.requests.post")
+    # def test_get_items_data_metadata_with_all(self, client_req_mock, get_token_mock):
+    #     test_case = self.test_cases[1]
+    #     get_token_mock.return_value = self.mock_access_token
+    #     client_req_mock.return_value.ok = True
+    #     client_req_mock.return_value.json = lambda: test_case["response"]
 
-    @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
-    @patch("pyclarify.client.requests.post")
-    def test_get_items_data_metadata_with_all(self, client_req_mock, get_token_mock):
-        test_case = self.test_cases[1]
-        get_token_mock.return_value = self.mock_access_token
-        client_req_mock.return_value.ok = True
-        client_req_mock.return_value.json = lambda: test_case["response"]
+    #     response_data = self.client.select_items(
+    #         filter=Filter(**test_case["args"]["filter"]),
+    #         skip=test_case["args"]["skip"],
+    #         not_before=test_case["args"]["not_before"],
+    #         before=test_case["args"]["before"],
+    #         rollup=test_case["args"]["rollup"],
+    #     )
 
-        response_data = self.client.select_items(
-            filter=Filter(**test_case["args"]["filter"]),
-            skip=test_case["args"]["skip"],
-            not_before=test_case["args"]["not_before"],
-            before=test_case["args"]["before"],
-            rollup=test_case["args"]["rollup"],
-        )
-
-        self.assertIsNone(response_data.result.items)
-        self.assertIsInstance(response_data.result.data, DataFrame)
-        self.assertIsNone(response_data.error)
+    #     self.assertIsNone(response_data.result.data)
+    #     self.assertIsInstance(response_data.result.data, DataFrame)
+    #     self.assertIsNone(response_data.error)
 
     @patch("pyclarify.jsonrpc.client.JSONRPCClient.get_token")
     @patch("pyclarify.client.requests.post")
@@ -183,8 +183,8 @@ class TestClarifyClientSelectItems(unittest.TestCase):
 
         response_data = self.client.select_items(**test_case["args"])
 
-        for x in response_data.result.items:
-            self.assertIsInstance(response_data.result.items[x], ItemInfo)
+        for x in response_data.result.data:
+            self.assertIsInstance(x, ItemSelectView)
 
 
 if __name__ == "__main__":

--- a/tests/test_models_request.py
+++ b/tests/test_models_request.py
@@ -136,7 +136,7 @@ class TestClarifyNamespaceParams(unittest.TestCase):
             self.fail("SelectItemsParams raised ValidationError unexpectedly!")
 
         try:
-            SelectItemsParams(items={}, data={})
+            SelectItemsParams(query= {"filter": {}}, include=[], groupIncludedByType = False)
         except ValidationError:
             self.fail("SelectItemsParams raised ValidationError unexpectedly!")
 


### PR DESCRIPTION
**NB!** This PR updates the API version from `1.1beta1` to `1.1beta2`, breaking other methods. 

- Updated payload and response for `select_items` method.
- Add new `ResourceMetadata` model
- Renamed old `ResourceMetadata` to `SignalResourceMetadata`
- Updated `ResourceQuery` to fit JSON:API
- Removed `select_items` method from iterator
- Updated `SelectItemsParams`
- Add `ItemSelectView` and `ItemSaveView`
- Updated tests.


NB! Did not _finish_ updating the select items area due to query being reworked. 