### PR TITLE
Version 0.4.3b0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,17 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [0.4.3] - 2022-12-22
+## [0.4.3] - 2023-02-20
+
+### Added
+
+- Added possibility to directly insert pd.DataFrame, pd.Series and dictionaries into Clarify. NB! Infers timestamp column and only supports when there only exists one timestamp column.
 
 ### Fixed
 
 - Fixed bug where the response was not JSON encoded causing error initialization to fail. Added more tests to check for such issues.
 - Fixed bug where Filter did not allow dictionary without comparison as an input argument for the filter.
+- Fixed included list containing multiple instances of same object.
 
 ## [0.4.2] - 2022-12-16
 

--- a/src/pyclarify/__init__.py
+++ b/src/pyclarify/__init__.py
@@ -18,5 +18,5 @@ from pyclarify.client import Client
 from pyclarify.views import Signal, SignalInfo, Item, ItemInfo, DataFrame
 import pyclarify.query
 
-__version__ = "0.4.3a0"
+__version__ = "0.4.3b0"
 __API_version__ = "1.1beta2"

--- a/src/pyclarify/__utils__/time.py
+++ b/src/pyclarify/__utils__/time.py
@@ -35,3 +35,7 @@ def compute_iso_timewindow(start_time, end_time):
         end_time = parse_datetime(end_time)
         start_time = parse_datetime(start_time)
     return start_time, end_time
+
+def is_datetime(value):
+    # if value is bigger than 1973
+    return parse_datetime(value) > parse_datetime(100000000)

--- a/src/pyclarify/__utils__/warnings.py
+++ b/src/pyclarify/__utils__/warnings.py
@@ -23,7 +23,7 @@ string_types = (type(b""), type(""))
 
 def deprecated(reason):
     """
-    Decorator which throws deprication warning.
+    Decorator which throws deprecation warning.
 
     Parameters
     ----------
@@ -84,3 +84,4 @@ def deprecated(reason):
 
     else:
         raise TypeError(repr(type(reason)))
+

--- a/src/pyclarify/client.py
+++ b/src/pyclarify/client.py
@@ -81,7 +81,7 @@ class Client(JSONRPCClient):
 
 
     @validate_arguments
-    def insert(self, data: DataFrame) -> Response:
+    def insert(self, data) -> Response:
         """
         This call inserts data to one or multiple signals. The signal is given an input id by the user. The signal is uniquely identified by its input ID in combination with
         the integration ID. If no signal with the given combination exists, an empty signal is created. With the creation of the signal, a unique signal id gets assigned to it.
@@ -89,8 +89,8 @@ class Client(JSONRPCClient):
 
         Parameters
         ----------
-        data : DataFrame
-            Dataframe containing the values of a signal in a key-value pair, and separate time axis. 
+        data : DataFrame, pd.DataFrame, dict
+            The data containing the values of a signal in a key-value pair, and separate time axis. 
 
         Returns
         -------
@@ -121,7 +121,7 @@ class Client(JSONRPCClient):
             >>> import pandas as pd
             >>> df = pd.DataFrame(data={"INPUT_ID_1": [1, 2], "INPUT_ID_2": [3, 4]})
             >>> df.index = ["2021-11-01T21:50:06Z",  "2021-11-02T21:50:06Z"]
-            >>> client.insert(DataFrame.from_pandas(df))
+            >>> client.insert(df)
 
 
         Response
@@ -156,6 +156,14 @@ class Client(JSONRPCClient):
                 ... )
 
         """
+        if not isinstance(data, DataFrame):
+            if hasattr(data, "__module__"):
+                if "pandas" in data.__module__:
+                    data = DataFrame.from_pandas(data)
+            if isinstance(data, dict):
+                data = DataFrame.from_dict(data)
+
+
         request_data = Request(
             method=ApiMethod.insert,
             params={"integration": self.authentication.integration_id, "data": data},

--- a/src/pyclarify/views/generics.py
+++ b/src/pyclarify/views/generics.py
@@ -133,6 +133,9 @@ class IncludedField(BaseModel, extra=Extra.ignore):
             data["items"] += other.items
         if self.items is None and other.items is None:
             data.pop("items", None)
+        else:
+            if len(data["items"]) > 1:
+                data["items"] = list(set(data["items"]))
         return IncludedField(**data)
 
 
@@ -153,6 +156,7 @@ class Selection(BaseModel):
                 data["included"] += other.included
             if self.included is None and other.included is None:
                 data.pop("included", None)
+
             return Selection(**data)
         except TypeError as e:
             raise TypeError(source=self, other=other) from e

--- a/src/pyclarify/views/items.py
+++ b/src/pyclarify/views/items.py
@@ -204,6 +204,13 @@ class ItemSelectView(BaseResource):
     """
     attributes: Item
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)): return NotImplemented
+        return self.id == other.id
+
 
 class ItemSaveView(Item):
     """


### PR DESCRIPTION
### Added

- Added possibility to directly insert `pd.DataFrame`, `pd.Series` and dictionaries into Clarify. NB! Infers timestamp column and only supports when there only exists one timestamp column.

### Fixed

- Fixed included list containing multiple instances of same object.