### PR TITLE
0.4.3b2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ clarify-credentials-prod.json
 
 # test files
 demofile.py
+production_test.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changes are grouped as follows
 
 - Added possibility to directly insert pd.DataFrame, pd.Series and dictionaries into Clarify. NB! Infers timestamp column and only supports when there only exists one timestamp column.
 - Added possibility to directly insert dictionaries to `pyclarify.client.data_frame`, `pyclarify.client.select_signals`, and `pyclarify.client.select_items`.
+- Added default timezone for general timestamp such as `datetime.today()`. This also applies to timestamps without explicit timezone.
 
 ### Fixed
 

--- a/src/pyclarify/__init__.py
+++ b/src/pyclarify/__init__.py
@@ -18,5 +18,5 @@ from pyclarify.client import Client
 from pyclarify.views import Signal, SignalInfo, Item, ItemInfo, DataFrame
 import pyclarify.query
 
-__version__ = "0.4.3b1"
+__version__ = "0.4.3b2"
 __API_version__ = "1.1beta2"

--- a/src/pyclarify/query/filter.py
+++ b/src/pyclarify/query/filter.py
@@ -18,6 +18,7 @@ from pyclarify.fields.query import Comparison, DateField, Operators
 from pydantic.class_validators import root_validator
 from pydantic import BaseModel
 from pydantic.fields import Optional
+from pydantic.datetime_parse import parse_datetime
 from typing import ForwardRef, Union, List, Dict
 from datetime import datetime
 
@@ -158,9 +159,9 @@ class DataFilter(BaseModel):
         lt = values["lt"] if "lt" in values.keys() else None
 
         if gte:
-            values["gte"] = DateField(operator=Operators.GTE, time=gte)
+            values["gte"] = DateField(operator=Operators.GTE, time=parse_datetime(gte).astimezone().isoformat())
         if lt:
-            values["lt"] = DateField(operator=Operators.LT, time=lt)
+            values["lt"] = DateField(operator=Operators.LT, time=parse_datetime(lt).astimezone().isoformat())
 
         return values
 


### PR DESCRIPTION
- Added default timezone for coarse timestamps such as `datetime.today()`. This also applies to timestamps without explicit timezone.