### PR TITLE
Version 0.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ from pyclarify import Client
 
 data = {
   "times": ["2022-10-10T00:00:00"],
-  "temperature": [19]
+  "series":
+    "temperature": [19],
+    "pressure": [1025]
+
 }
 
 client = Client("credentials.json")

--- a/src/pyclarify/__init__.py
+++ b/src/pyclarify/__init__.py
@@ -18,5 +18,5 @@ from pyclarify.client import Client
 from pyclarify.views import Signal, SignalInfo, Item, ItemInfo, DataFrame
 import pyclarify.query
 
-__version__ = "0.4.3b2"
+__version__ = "0.4.3"
 __API_version__ = "1.1beta2"

--- a/tests/utils/test_time.py
+++ b/tests/utils/test_time.py
@@ -1,0 +1,38 @@
+import unittest
+import sys
+
+sys.path.insert(1, "src/")
+from pyclarify.__utils__.time import is_datetime
+import datetime
+import numpy as np
+
+
+class TestTime(unittest.TestCase):
+    def test_possible_scenarios(self):
+        self.assertFalse(is_datetime(-1))
+        self.assertFalse(is_datetime(0))
+        self.assertFalse(is_datetime(1))
+        self.assertFalse(is_datetime(-1.0))
+        self.assertFalse(is_datetime(0.0))
+        self.assertFalse(is_datetime(1.0))
+        self.assertFalse(is_datetime(np.nan))
+        self.assertFalse(is_datetime("hello"))
+        self.assertFalse(is_datetime(""))
+        self.assertFalse(is_datetime("aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString"))
+        self.assertFalse(is_datetime(100000000000000000))
+        self.assertFalse(is_datetime(-10000000000))
+        # Timestamp of 2122
+        self.assertFalse(is_datetime(4800000000))
+        # Must be newer than 1973
+        self.assertFalse(is_datetime("1814-05-17T12:00:00+02:00"))
+
+        self.assertTrue(is_datetime("2020-01-01T00:00:00Z"))
+        self.assertTrue(is_datetime("2020-01-01T00:00:00+00:00"))
+        self.assertTrue(is_datetime("2020-01-01"))
+        self.assertTrue(is_datetime(datetime.datetime(year=2020,month=1,day=1,hour=0,minute=0,second=0)))
+        
+        # Timestamp of < 2122
+        self.assertTrue(is_datetime(4799999999))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/views/test_dataframe.py
+++ b/tests/views/test_dataframe.py
@@ -159,10 +159,30 @@ class TestGenericInput(unittest.TestCase):
         self.pandas = self.base.to_pandas()
 
         # Dictionary
-        self.dictionary = {"timestamps": times, "input_id":data}
+        self.dictionary = {
+            "timestamps": times, 
+            "series": {
+                "input_id": data
+            }
+        }
+
+        # Flat Dictionary
+        self.flat_dictionary = {
+            "timestamps": times, 
+            "input_id":data
+        }
 
         # Pandas series
         self.series = self.pandas["input_id"]
+
+        # Dict with two time inputs
+        self.invalid = {
+            "timestamps": times,
+            "series": {
+                "input_id1": times, 
+                "input_id2": data
+            }
+        }
 
     def test_convert_from_data_frame(self):
         df = DataFrame.from_pandas(self.pandas)
@@ -318,7 +338,7 @@ class TestGenericInput(unittest.TestCase):
 
         # Values
         # NB: Change numpy float to native float
-        values = self.dictionary["input_id"]
+        values = self.dictionary["series"]["input_id"]
 
         self.assertEqual(df.series["input_id"], values)
 
@@ -326,8 +346,8 @@ class TestGenericInput(unittest.TestCase):
         clarify_ts = [parse_datetime(x) for x in self.dictionary["timestamps"]]
         self.assertEqual(df.times, clarify_ts)
 
-    def test_convert_from_dictionary_with_input(self):
-        df = DataFrame.from_dict(self.dictionary, time_col="timestamps")
+    def test_convert_from_flat_dictionary(self):
+        df = DataFrame.from_dict(self.flat_dictionary)
 
         # Is of type pyclarify.DataFrame
         self.assertIsInstance(df, DataFrame)
@@ -339,13 +359,19 @@ class TestGenericInput(unittest.TestCase):
 
         # Values
         # NB: Change numpy float to native float
-        values = self.dictionary["input_id"]
+        values = self.flat_dictionary["input_id"]
 
         self.assertEqual(df.series["input_id"], values)
 
         # Times
-        clarify_ts = [parse_datetime(x) for x in self.dictionary["timestamps"]]
+        clarify_ts = [parse_datetime(x) for x in self.flat_dictionary["timestamps"]]
         self.assertEqual(df.times, clarify_ts)
+
+    
+    def test_convert_from_invalid_dictionary(self):
+        # Cannot impute time column when two is present
+        with self.assertRaises(ValueError):
+            df = DataFrame.from_dict(self.invalid)
 
 
 class TestSummary(unittest.TestCase):


### PR DESCRIPTION
## [0.4.3] - 2023-02-20

### Added

- Added possibility to directly insert pd.DataFrame, pd.Series and dictionaries into Clarify. NB! Infers timestamp column and only supports when there only exists one timestamp column.
- Added possibility to directly insert dictionaries to `pyclarify.client.data_frame`, `pyclarify.client.select_signals`, and `pyclarify.client.select_items`.
- Added default timezone for general timestamp such as `datetime.today()`. This also applies to timestamps without explicit timezone.

### Fixed

- Fixed bug where the response was not JSON encoded causing error initialization to fail. Added more tests to check for such issues.
- Fixed bug where Filter did not allow dictionary without comparison as an input argument for the filter.
- Fixed included list containing multiple instances of same object.