### PR TITLE
:bug: Fix to iteration of requests and empty signal response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,5 @@ clarify-credentials-prod.json
 # test files
 demofile.py
 production_test.py
+stress_test.py
 test.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ flake8==4.0.1
 pytest==6.2.5
 build==0.7.0
 requests>=2.31.0
-pydantic>=1.8.2
-typing_extensions==3.10.0.2
+pydantic==1.10.2
+typing_extensions==4.7.1
 pandas==1.3.4

--- a/src/pyclarify/__utils__/stopping_conditions.py
+++ b/src/pyclarify/__utils__/stopping_conditions.py
@@ -3,8 +3,9 @@ from pyclarify.views.generics import Response
 
 def select_stopping_condition(response: Response):
     if hasattr(response.result, "data"):
-        if len(response.result.data) < 1000:
-            return True
+        if response.result.data:
+            if len(response.result.data) < 1000:
+                return True
     else:
         return True
     return False

--- a/src/pyclarify/client.py
+++ b/src/pyclarify/client.py
@@ -116,12 +116,7 @@ class Client(JSONRPCClient):
                 responses = response
             else:
                 responses += response
-
-            if (
-                stopping_condition(response)
-                if isinstance(stopping_condition, Callable)
-                else False
-            ):
+            if stopping_condition(response) if isinstance(stopping_condition, Callable) else False:
                 return responses
         return responses
 

--- a/src/pyclarify/jsonrpc/client.py
+++ b/src/pyclarify/jsonrpc/client.py
@@ -96,7 +96,7 @@ class JSONRPCClient:
         res = requests.post(
             self.base_url, data=payload, headers=self.headers
         )
-        logging.debug(f"{self.current_id}<-- {self.base_url} ({res.status_code}) ")#\n res:{res.json()}")
+        logging.debug(f"{self.current_id}<-- {self.base_url} ({res.status_code})  res:{res.json()}")
         return res
 
     @increment_id

--- a/src/pyclarify/views/dataframe.py
+++ b/src/pyclarify/views/dataframe.py
@@ -335,8 +335,13 @@ class DataFrame(BaseModel):
 
     def __add__(self, other):
         try:
-            data = DataFrame.merge([self, other])
-            return data
+            if isinstance(other, DataFrame):
+                data = DataFrame.merge([self, other])
+                return data
+            elif isinstance(other, dict):
+                data = DataFrame.merge([self, DataFrame.from_dict(other)])
+            else:
+                data = DataFrame.merge([self, DataFrame.from_pandas(other)])
         except TypeError as e:
             raise TypeError(source=self, other=other) from e
 

--- a/src/pyclarify/views/generics.py
+++ b/src/pyclarify/views/generics.py
@@ -146,7 +146,7 @@ class SignalSelection(Selection):
 class GenericResponse(BaseModel, extra=Extra.forbid):
     jsonrpc: str = "2.0"
     id: str
-    result: Optional[dict]
+    result: Optional[Union[InsertResponse,SaveSignalsResponse,DataSelection,ItemSelection,SignalSelection,PublishSignalsResponse]]
     error: Union[Error, List[Error], None]
 
 
@@ -161,22 +161,31 @@ class Response(GenericResponse):
         error = values.get("error")
         if result:
             if method == ApiMethod.insert:
-                values["result"] = InsertResponse(**result)
+                if not isinstance(result, InsertResponse):
+                    values["result"] = InsertResponse(**result.dict())
 
             elif method == ApiMethod.save_signals:
-                values["result"] = SaveSignalsResponse(**result)
+                if not isinstance(result, SaveSignalsResponse):
+                    values["result"] = SaveSignalsResponse(**result.dict())
             
             elif method == ApiMethod.data_frame or method == ApiMethod.evaluate:
-                values["result"] = DataSelection(**result)
+                if not isinstance(result, DataSelection):
+                    values["result"] = DataSelection(**result.dict())
             
             elif method == ApiMethod.select_items:
-                values["result"] = ItemSelection(**result)
+                if not isinstance(result, ItemSelection):
+                    values["result"] = ItemSelection(**result.dict())
 
             elif method == ApiMethod.select_signals:
-                values["result"] = SignalSelection(**result)
+                if not isinstance(result, SignalSelection):
+                    values["result"] = SignalSelection(**result.dict())
 
             elif method == ApiMethod.publish_signals:
-                values["result"] = PublishSignalsResponse(**result)
+                if not isinstance(result, PublishSignalsResponse):
+                    values["result"] = PublishSignalsResponse(**result.dict())
+            else:
+                # If has no method signature, assume its a valid object type
+                return values
         elif error:          
             pass #TODO: Possible error state 
         values.pop("method") # no need anymore for declaring method

--- a/src/pyclarify/views/generics.py
+++ b/src/pyclarify/views/generics.py
@@ -15,7 +15,7 @@
 
 from datetime import datetime, timedelta
 import pydantic
-from pydantic import BaseModel, validate_arguments, Extra
+from pydantic import BaseModel, validate_arguments, Extra, validator
 from pydantic.json import timedelta_isoformat
 from pyclarify.__utils__.time import time_to_string
 from pyclarify.__utils__.exceptions import TypeError
@@ -117,41 +117,36 @@ class Selection(BaseModel):
 
     def __add__(self, other):
         try:
-            data = {}
-            data["meta"] = self.meta
-            data["data"] = self.data + other.data
-            if self.included is not None:
-                data["included"] = self.included
-            if other.included is not None:
-                if data["included"] is not None:
-                    data["included"] += other.included
-                else:
-                    data["included"] = other.included
-            if self.included is None and other.included is None:
-                data.pop("included", None)
-
-            return self.__class__(**data)
+            self.data += other.data
+            if self.included:
+                if other.included:
+                    self.included += other.included
+            elif other.included:
+                self.included = other.included
+            
+            return self
         except TypeError as e:
             raise TypeError(source=self, other=other) from e
 
 class DataSelection(Selection):
-    data:  DataFrame
+    data: DataFrame
     included: Optional[IncludedFieldSignals]
 
 
 class ItemSelection(Selection):
-    data: List[ItemSelectView]
+    data: Optional[List[ItemSelectView]]
     included: Optional[IncludedFieldItems]
 
-class SignalSelection(Selection):
-    data:  List[SignalSelectView]
-    included: Optional[IncludedFieldSignals]
 
+class SignalSelection(Selection):
+    data:  Optional[List[SignalSelectView]]
+    included: Optional[IncludedFieldSignals]
+    
 
 class GenericResponse(BaseModel, extra=Extra.forbid):
     jsonrpc: str = "2.0"
     id: str
-    result: Optional[Union[InsertResponse,SaveSignalsResponse,DataSelection,ItemSelection,SignalSelection,PublishSignalsResponse]]
+    result: Optional[dict]
     error: Union[Error, List[Error], None]
 
 
@@ -163,31 +158,26 @@ class Response(GenericResponse):
         #TODO: Not happy with this resolution flow
         result = values.get("result")
         method = values.get("method")
+        error = values.get("error")
         if result:
             if method == ApiMethod.insert:
-                if not isinstance(result, InsertResponse):
-                    values["result"] = InsertResponse(**result.dict())
+                values["result"] = InsertResponse(**result)
 
             elif method == ApiMethod.save_signals:
-                if not isinstance(result, SaveSignalsResponse):
-                    values["result"] = SaveSignalsResponse(**result.dict())
+                values["result"] = SaveSignalsResponse(**result)
             
             elif method == ApiMethod.data_frame or method == ApiMethod.evaluate:
-                if not isinstance(result, DataSelection):
-                    values["result"] = DataSelection(**result.dict())
+                values["result"] = DataSelection(**result)
             
             elif method == ApiMethod.select_items:
-                if not isinstance(result, ItemSelection):
-                    values["result"] = ItemSelection(**result.dict())
+                values["result"] = ItemSelection(**result)
 
             elif method == ApiMethod.select_signals:
-                if not isinstance(result, SignalSelection):
-                    values["result"] = SignalSelection(**result.dict())
+                values["result"] = SignalSelection(**result)
 
             elif method == ApiMethod.publish_signals:
-                if not isinstance(result, PublishSignalsResponse):
-                    values["result"] = PublishSignalsResponse(**result.dict())
-        else:
+                values["result"] = PublishSignalsResponse(**result)
+        elif error:          
             pass #TODO: Possible error state 
         values.pop("method") # no need anymore for declaring method
         return values
@@ -202,23 +192,21 @@ class Response(GenericResponse):
                     results += other.result
             elif other.result:
                 results = other.result
+            if results:
+                self.result = results
+
             if self.error:
                 errors = self.error
                 if other.error:
                     if isinstance(self.error, List):
-                        if isinstance(other.error, List):
-                            errors = self.error + other.error
-                        else:
-                            errors = self.error + [other.error]
-                    elif isinstance(other.error, List):
-                        errors = [self.error] + other.error
+                        errors = self.error + [other.error]
                     else:
                         errors = [self.error, other.error]
             elif other.error:
                 errors = other.error
-
-            return Response(
-                jsonrpc=self.jsonrpc, id=self.id, result=results, error=errors
-            )
+            if errors:
+                self.error = errors
+            
+            return self
         except TypeError as e:
             raise TypeError(source=self, other=other) from e


### PR DESCRIPTION
## Iteration of requests
A bug where calling large data_frames sometimes wouldn't allow joining due to one of the responses being parsed as a dictionary instead of DataFrame class.

## Empty select_signals response
Empty signal responses resulted in a breaking due to pydantic parsing an empty list as a None value. #162  