### PR TITLE
Version 0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.6.5] - 2024-09-17
+
+## Fixed
+
+- Bug where ExperimentalClient would not except new API methods.
+
 ## [0.6.4] - 2024-09-16
 
 ### Added

--- a/src/pyclarify/__init__.py
+++ b/src/pyclarify/__init__.py
@@ -25,5 +25,5 @@ from pyclarify.views import (
 )
 import pyclarify.query
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 __API_version__ = "1.1"

--- a/src/pyclarify/experimental.py
+++ b/src/pyclarify/experimental.py
@@ -48,7 +48,7 @@ class JSONRPCRequest(BaseModel):
 
 
 class ExperimentalRequest(JSONRPCRequest):
-    method: ApiMethod
+    method: ExperimentalApiMethod
 
     @model_validator(mode='after')
     @classmethod


### PR DESCRIPTION
## [0.6.5] - 2024-09-17

## Fixed

- Bug where ExperimentalClient would not except new API methods.
